### PR TITLE
add compression, tarball_extension options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,14 @@ Here are all of the available configuration options (and their defaults) for thi
       "_comment": "The directory to write artifacts to",
       "output": "packer_{{.BuildName}}_tarball",
 
-      "_comment": "Filename to use for the artifact. `.tar.gz` will be appended to the end",
+      "_comment": "Filename to use for the artifact. `tarball_extension` will be appended to the end",
       "tarball_filename": "packer_{{.BuildName}}",
+
+      "_comment": "Filename extension to use",
+      "tarball_extension": ".tar.xz",
+
+      "_comment": "Compression type (see tar-out in `man guestfish` for supported types)",
+      "compression": "xz",
 
       "_comment": "The Guestfish binary to use",
       "guestfish_binary": "guestfish",


### PR DESCRIPTION
This allows me to specify a different compression, along with matching file extension. Defaults to xz compression, as I _assume_ people prefer it.

BTW, as you assume, this is useful for more than OpenVZ. I'm building an image in a vm for use with hardware appliances. :)
